### PR TITLE
quick alignment between tests and backend APIs

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -17,7 +17,6 @@
         "firebase": "^11.1.0",
         "firebase-admin": "^13.0.2",
         "helmet": "^8.0.0",
-        "jsonwebtoken": "^9.0.2",
         "morgan": "^1.10.0",
         "winston": "^3.17.0"
       },

--- a/backend/package.json
+++ b/backend/package.json
@@ -25,7 +25,6 @@
     "firebase": "^11.1.0",
     "firebase-admin": "^13.0.2",
     "helmet": "^8.0.0",
-    "jsonwebtoken": "^9.0.2",
     "morgan": "^1.10.0",
     "winston": "^3.17.0"
   },

--- a/backend/src/controllers/AuthController.ts
+++ b/backend/src/controllers/AuthController.ts
@@ -20,7 +20,7 @@ export class AuthController {
         try {
           const sessionCookie = await this.authService.createSessionCookie(result.token);
 
-          const expiresIn = 60 * 60 * 24 * 5 * 1000; // 5 days
+          const expiresIn = 60 * 60 * 24 * 5 * 1000; // 5 days, equivalent to Max-Age=432000
           res.cookie("sessionToken", sessionCookie, {
             httpOnly: true,
             secure: process.env.NODE_ENV === "prod",
@@ -74,7 +74,7 @@ export class AuthController {
         sameSite: "strict",
       });
 
-      res.status(200).json({ message: "Logout successful" });
+      res.status(204).end();
     } catch (error: unknown) {
       this.sendUnknownErrorResponse(res, 500, error);
     }

--- a/backend/src/routes/APIRouter.ts
+++ b/backend/src/routes/APIRouter.ts
@@ -1,5 +1,4 @@
 import { AuthService } from "../services/AuthService";
-import { FirebaseService } from "../services/FirebaseService";
 import { UserService } from "../services/UserService";
 import { AuthRouter } from "./AuthRouter";
 import { BaseRouter } from "./BaseRouter";
@@ -8,17 +7,15 @@ import { UserRouter } from "./UserRouter";
 export class APIRouter extends BaseRouter {
   private authService: AuthService;
   private userService: UserService;
-  private firebaseService: FirebaseService;
 
-  constructor(authService: AuthService, userService: UserService, firebaseService: FirebaseService) {
+  constructor(authService: AuthService, userService: UserService) {
     super();
-    this.firebaseService = firebaseService;
-    this.authService = authService || new AuthService(this.firebaseService);
-    this.userService = userService || new UserService(this.firebaseService);
+    this.authService = authService;
+    this.userService = userService;
   }
 
   protected initializeRoutes(): void {
-    this.router.use("/auth", new AuthRouter(this.firebaseService, this.authService).getRouter());
-    this.router.use("/user", new UserRouter(this.firebaseService, this.userService).getRouter());
+    this.router.use("/auth", new AuthRouter(this.authService).getRouter());
+    this.router.use("/user", new UserRouter(this.userService).getRouter());
   }
 }

--- a/backend/src/routes/AuthRouter.ts
+++ b/backend/src/routes/AuthRouter.ts
@@ -1,15 +1,13 @@
 import { BaseRouter } from "./BaseRouter";
 import { AuthController } from "../controllers/AuthController";
 import { AuthService } from "../services/AuthService";
-import { FirebaseService } from "../services/FirebaseService";
 
 export class AuthRouter extends BaseRouter {
   private authController: AuthController;
 
-  constructor(firebaseService: FirebaseService, authService?: AuthService) {
+  constructor(authService: AuthService) {
     super();
-    const service = authService || new AuthService(firebaseService);
-    this.authController = new AuthController(service);
+    this.authController = new AuthController(authService);
   }
 
   protected initializeRoutes(): void {

--- a/backend/src/routes/UserRouter.ts
+++ b/backend/src/routes/UserRouter.ts
@@ -2,15 +2,13 @@ import { BaseRouter } from "./BaseRouter";
 import { UserController } from "../controllers/UserController";
 import { AuthenticateSession } from "../middleware/AuthenticateSession";
 import { UserService } from "../services/UserService";
-import { FirebaseService } from "../services/FirebaseService";
 
 export class UserRouter extends BaseRouter {
   private userController: UserController;
 
-  constructor(firebaseService: FirebaseService, userService?: UserService) {
+  constructor(userService: UserService) {
     super();
-    const service = userService || new UserService(firebaseService);
-    this.userController = new UserController(service);
+    this.userController = new UserController(userService);
   }
 
   protected initializeRoutes(): void {

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -3,8 +3,6 @@ import https from "https";
 import { Logger } from "./utils/Logger";
 import fs from "fs";
 import path from "path";
-import { AuthService } from "./services/AuthService";
-import { UserService } from "./services/UserService";
 import { FirebaseService } from "./services/FirebaseService";
 
 const PORT = parseInt(process.env.BPORT || "4000", 10);
@@ -18,15 +16,9 @@ const sslOptions = {
 };
 
 const firebaseService = new FirebaseService();
-const authService = new AuthService(firebaseService);
-const userService = new UserService(firebaseService);
 const logger = Logger.getInstance();
 
-const appDependencies: AppDependencies = {
-  authService,
-  userService,
-  firebaseService,
-};
+const appDependencies: AppDependencies = { firebaseService };
 
 const app = createApp(appDependencies);
 

--- a/backend/src/services/FirebaseService.ts
+++ b/backend/src/services/FirebaseService.ts
@@ -3,7 +3,7 @@ import admin from "firebase-admin";
 import { initializeApp, FirebaseApp, getApps, getApp } from "firebase/app";
 import { Firestore, getFirestore } from "firebase/firestore";
 import { App } from "firebase-admin/app";
-import { Auth as AdminAuth } from "firebase-admin/auth";
+import { Auth as AdminAuth, DecodedIdToken } from "firebase-admin/auth";
 
 export type FirebaseConfig = {
   apiKey: string;
@@ -55,5 +55,9 @@ export class FirebaseService {
 
   getAdminAuth(): AdminAuth {
     return admin.auth();
+  }
+
+  async verifySessionCookie(sessionToken: string): Promise<DecodedIdToken> {
+    return this.getAdminAuth().verifySessionCookie(sessionToken);
   }
 }

--- a/backend/tests/controllers/AuthController.test.ts
+++ b/backend/tests/controllers/AuthController.test.ts
@@ -25,6 +25,7 @@ describe("AuthController", () => {
         user: { id: "mockUserId", email: "test@example.com" },
       }),
       verifyToken: jest.fn().mockResolvedValue({ uid: "test-uid", email: "test@example.com" }),
+      createSessionCookie: jest.fn().mockResolvedValue("mock-session-cookie"),
     } as unknown as jest.Mocked<AuthService>;
 
     firebaseService = {
@@ -33,7 +34,11 @@ describe("AuthController", () => {
 
     userService = {} as jest.Mocked<UserService>;
 
-    const appDependencies: AppDependencies = { authService, userService, firebaseService };
+    const appDependencies: AppDependencies = { firebaseService };
+
+    (AuthService as jest.Mock) = jest.fn().mockImplementation(() => authService);
+    (UserService as jest.Mock) = jest.fn().mockImplementation(() => userService);
+    (FirebaseService as jest.Mock) = jest.fn().mockImplementation(() => firebaseService);
     app = createApp(appDependencies);
   });
 
@@ -58,7 +63,7 @@ describe("AuthController", () => {
       const cookie = response.headers["set-cookie"][0];
       expect(cookie).toContain("HttpOnly");
       expect(cookie).toContain("SameSite=Strict");
-      expect(cookie).toContain("Max-Age=3600");
+      expect(cookie).toContain("Max-Age=432000");
     });
 
     it("should return 400 when login fails due to invalid credentials", async () => {

--- a/backend/tests/controllers/UserController.test.ts
+++ b/backend/tests/controllers/UserController.test.ts
@@ -1,7 +1,5 @@
 import request from "supertest";
 import createApp, { AppDependencies } from "../../src/app";
-import { AuthService } from "../../src/services/AuthService";
-import { UserService } from "../../src/services/UserService";
 import { FirebaseService } from "../../src/services/FirebaseService";
 
 jest.mock("../../src/services/AuthService");
@@ -9,8 +7,6 @@ jest.mock("../../src/services/UserService");
 
 describe("UserController", () => {
   let firebaseService: jest.Mocked<FirebaseService>;
-  let authService: jest.Mocked<AuthService>;
-  let userService: jest.Mocked<UserService>;
   let app: ReturnType<typeof createApp>;
 
   beforeEach(() => {
@@ -19,10 +15,7 @@ describe("UserController", () => {
       getFirestore: jest.fn(),
     } as unknown as jest.Mocked<FirebaseService>;
 
-    authService = new AuthService(firebaseService) as jest.Mocked<AuthService>;
-    userService = new UserService(firebaseService) as jest.Mocked<UserService>;
-
-    const appDependencies: AppDependencies = { authService, userService, firebaseService };
+    const appDependencies: AppDependencies = { firebaseService };
     app = createApp(appDependencies);
   });
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,28 +1,32 @@
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 
-interface AuthResult {
-  token: string;
-  user: {
-    uid: string;
-    email: string;
-  };
+interface User {
+  uid: string;
+  email: string;
 }
-interface ValidateSessionResult extends AuthResult {
+
+interface AuthResponse {
+  user: User;
+  message: string;
+}
+
+interface ValidateSessionResult {
   valid: boolean;
+  user: User;
 }
 
 export const api = createApi({
   reducerPath: "api",
   baseQuery: fetchBaseQuery({ baseUrl: "https://localhost:4000/api", credentials: "include" }),
   endpoints: (builder) => ({
-    login: builder.mutation<AuthResult, { email: string; password: string }>({
+    login: builder.mutation<AuthResponse, { email: string; password: string }>({
       query: (credentials) => ({
         url: "auth/login",
         method: "POST",
         body: credentials,
       }),
     }),
-    register: builder.mutation<AuthResult, { email: string; password: string }>({
+    register: builder.mutation<AuthResponse, { email: string; password: string }>({
       query: (credentials) => ({
         url: "auth/register",
         method: "POST",
@@ -35,7 +39,7 @@ export const api = createApi({
         method: "POST",
       }),
     }),
-    resetPassword: builder.mutation<any, { email: string }>({
+    resetPassword: builder.mutation<AuthResponse, { email: string }>({
       query: (credentials) => ({
         url: "auth/reset-password",
         method: "POST",


### PR DESCRIPTION
- updated backend tests per recent changes; added new tests for `api/auth/logout`, `api/auth/resetPassword`, and `api/auth/validateSession`
- removed `jsonwebtoken` since AuthenticateSession middleware now aligns with Firebase session cookie implementation of creation/verification
- made some corrections to how `app.ts` injects dependencies in `createApp()`, specifically ensuring `AuthService` and `UserService` only get instantiated once and in one place whereas before it wasn't explicitly doing so consistently
- added explicit typing to RTK Query `api.ts` so query endpoints are clearly defined